### PR TITLE
chore(manifest): specify version 0.0.1 to please HA

### DIFF
--- a/custom_components/wallbox/manifest.json
+++ b/custom_components/wallbox/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "wallbox",
   "name": "Wallbox",
+  "version": "0.0.1",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wallbox",
   "requirements": [


### PR DESCRIPTION
HA will refuse to load this integration unless a version is specified in the manifest.

```
No 'version' key in the manifest file for custom integration 'wallbox'. As of Home Assistant 2021.6, this integration will no longer be loaded. Please report this to the maintainer of 'wallbox'
```