### PR TITLE
Fix breaking change ATTR_UNIT

### DIFF
--- a/custom_components/wallbox/const.py
+++ b/custom_components/wallbox/const.py
@@ -1,6 +1,6 @@
 """Constants for the Wallbox integration."""
 from homeassistant.const import (
-    ELECTRICAL_CURRENT_AMPERE,
+    ELECTRIC_CURRENT_AMPERE,
     ENERGY_KILO_WATT_HOUR,
     LENGTH_KILOMETERS,
     PERCENTAGE,
@@ -26,7 +26,7 @@ SENSOR_TYPES = {
         "ATTR_ICON": "mdi:ev-station",
         "ATTR_LABEL": "Max Available Power",
         "ATTR_ROUND": 0,
-        "ATTR_UNIT": ELECTRICAL_CURRENT_AMPERE,
+        "ATTR_UNIT": ELECTRIC_CURRENT_AMPERE,
         "ATTR_ENABLED": True,
     },
     "charging_speed": {

--- a/custom_components/wallbox/number.py
+++ b/custom_components/wallbox/number.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
-from homeassistant.const import ELECTRI_CURRENT_AMPERE
+from homeassistant.const import ELECTRIC_CURRENT_AMPERE
 
 from .const import CONF_CONNECTIONS, CONF_STATION, DOMAIN
 

--- a/custom_components/wallbox/number.py
+++ b/custom_components/wallbox/number.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
-from homeassistant.const import ELECTRICAL_CURRENT_AMPERE
+from homeassistant.const import ELECTRI_CURRENT_AMPERE
 
 from .const import CONF_CONNECTIONS, CONF_STATION, DOMAIN
 
@@ -71,7 +71,7 @@ class WallboxMaxChargingCurrent(CoordinatorEntity, NumberEntity):
         self._is_on = False
         self._name = name
         self.station = config.data[CONF_STATION]
-        self._unit = ELECTRICAL_CURRENT_AMPERE
+        self._unit = ELECTRIC_CURRENT_AMPERE
 
     def set_max_charging_current(self, max_charging_current):
         """Set max charging current using API."""


### PR DESCRIPTION
Fixed "Max Available Power" unit of measurement that breaks the integration.

https://github.com/home-assistant/core/pull/53243 breaks this integration